### PR TITLE
Reduce api read calls

### DIFF
--- a/serverscom/resource_serverscom_dedicated_server.go
+++ b/serverscom/resource_serverscom_dedicated_server.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	scgo "github.com/serverscom/serverscom-go-client/pkg"
@@ -286,7 +286,7 @@ func resourceServerscomDedicatedServerDelete(d *schema.ResourceData, meta interf
 	}
 
 	if dedicatedServer.Status == "pending" || dedicatedServer.Status == "init" {
-		_, err = waitForDedicatedServerAttribute(d, "active", []string{"init", "pending"}, "status", meta, schema.TimeoutDelete)
+		_, err = waitForDedicatedServerAttribute(ctx, d, "active", []string{"init", "pending"}, "status", meta, schema.TimeoutDelete)
 		if err != nil {
 			return fmt.Errorf("Error waiting for dedicated server (%s) to become ready: %s", d.Id(), err)
 		}
@@ -451,12 +451,12 @@ func resourceServerscomDedicatedServerCreate(d *schema.ResourceData, meta interf
 
 	d.SetId(id)
 
-	_, err = waitForDedicatedServerAttribute(d, "active", []string{"init", "pending"}, "status", meta, schema.TimeoutCreate)
+	_, err = waitForDedicatedServerAttribute(ctx, d, "active", []string{"init", "pending"}, "status", meta, schema.TimeoutCreate)
 	if err != nil {
 		return fmt.Errorf("Error waiting for dedicated server (%s) to become ready: %s", d.Id(), err)
 	}
 
-	return resourceServerscomDedicatedServerRead(d, meta)
+	return nil
 }
 
 func getDriveSlots(slots []scgo.HostDriveSlot) []map[string]interface{} {
@@ -678,29 +678,25 @@ func verifyLayouts(layouts []scgo.DedicatedServerLayoutInput) error {
 	return nil
 }
 
-func waitForDedicatedServerAttribute(d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}, timeoutKey string) (interface{}, error) {
+func waitForDedicatedServerAttribute(ctx context.Context, d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}, timeoutKey string) (interface{}, error) {
 	log.Printf(
 		"[INFO] Waiting for dedicated server (%s) to have %s of %s",
 		d.Id(), attribute, target,
 	)
 
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:      pending,
 		Target:       []string{target},
 		Refresh:      newDedicatedServerStateRefreshFunc(d, attribute, meta),
 		Timeout:      d.Timeout(timeoutKey),
 		PollInterval: 1 * time.Minute,
 		Delay:        1 * time.Minute,
-		MinTimeout:   30 * time.Second,
 	}
 
-	return stateConf.WaitForState()
+	return stateConf.WaitForStateContext(ctx)
 }
 
-func newDedicatedServerStateRefreshFunc(d *schema.ResourceData, attribute string, meta interface{}) resource.StateRefreshFunc {
-	client := meta.(*scgo.Client)
-	ctx := context.TODO()
-
+func newDedicatedServerStateRefreshFunc(d *schema.ResourceData, attribute string, meta interface{}) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		err := resourceServerscomDedicatedServerRead(d, meta)
 		if err != nil {
@@ -708,18 +704,12 @@ func newDedicatedServerStateRefreshFunc(d *schema.ResourceData, attribute string
 		}
 
 		// See if we can access our attribute
-		if attr, ok := d.GetOkExists(attribute); ok {
-			dedicatedServer, err := client.Hosts.GetDedicatedServer(ctx, d.Id())
-
-			if err != nil {
-				return nil, "", fmt.Errorf("Error retrieving dedicated server: %s", err)
-			}
-
+		if attr, ok := d.GetOk(attribute); ok {
 			switch attr.(type) {
 			case bool:
-				return &dedicatedServer, strconv.FormatBool(attr.(bool)), nil
+				return d, strconv.FormatBool(attr.(bool)), nil
 			default:
-				return &dedicatedServer, attr.(string), nil
+				return d, attr.(string), nil
 			}
 		}
 

--- a/serverscom/resource_serverscom_l2_segment.go
+++ b/serverscom/resource_serverscom_l2_segment.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	scgo "github.com/serverscom/serverscom-go-client/pkg"
@@ -26,7 +26,7 @@ func resourceServerscomL2Segment() *schema.Resource {
 		Delete: resourceServerscomL2SegmentDelete,
 		Create: resourceServerscomL2SegmentCreate,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -167,7 +167,7 @@ func resourceServerscomL2SegmentUpdate(d *schema.ResourceData, meta interface{})
 
 		ctx := context.TODO()
 
-		if _, err := waitForL2SegmentAttribute(d, "active", []string{"pending"}, "status", meta, schema.TimeoutUpdate); err != nil {
+		if _, err := waitForL2SegmentAttribute(ctx, d, "active", []string{"pending"}, "status", meta, schema.TimeoutUpdate); err != nil {
 			return err
 		}
 
@@ -175,7 +175,7 @@ func resourceServerscomL2SegmentUpdate(d *schema.ResourceData, meta interface{})
 			return err
 		}
 
-		if _, err := waitForL2SegmentAttribute(d, "active", []string{"pending"}, "status", meta, schema.TimeoutUpdate); err != nil {
+		if _, err := waitForL2SegmentAttribute(ctx, d, "active", []string{"pending"}, "status", meta, schema.TimeoutUpdate); err != nil {
 			return err
 		}
 
@@ -209,7 +209,7 @@ func resourceServerscomL2SegmentDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	if l2Segment.Status == "pending" {
-		if _, err := waitForL2SegmentAttribute(d, "active", []string{"pending"}, "status", meta, schema.TimeoutDelete); err != nil {
+		if _, err := waitForL2SegmentAttribute(ctx, d, "active", []string{"pending"}, "status", meta, schema.TimeoutDelete); err != nil {
 			return err
 		}
 	}
@@ -243,11 +243,11 @@ func resourceServerscomL2SegmentCreate(d *schema.ResourceData, meta interface{})
 
 	d.SetId(l2Segment.ID)
 
-	if _, err := waitForL2SegmentAttribute(d, "active", []string{"pending"}, "status", meta, schema.TimeoutCreate); err != nil {
+	if _, err := waitForL2SegmentAttribute(ctx, d, "active", []string{"pending"}, "status", meta, schema.TimeoutCreate); err != nil {
 		return err
 	}
 
-	return resourceServerscomL2SegmentRead(d, meta)
+	return nil
 }
 
 func getMembers(members []scgo.L2Member) []map[string]interface{} {
@@ -269,13 +269,13 @@ func getMembers(members []scgo.L2Member) []map[string]interface{} {
 	return l2Members
 }
 
-func waitForL2SegmentAttribute(d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}, timeoutKey string) (interface{}, error) {
+func waitForL2SegmentAttribute(ctx context.Context, d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}, timeoutKey string) (interface{}, error) {
 	log.Printf(
 		"[INFO] Waiting for l2 segment (%s) to have %s of %s",
 		d.Id(), attribute, target,
 	)
 
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:    pending,
 		Target:     []string{target},
 		Refresh:    newL2SegmentStateRefreshFunc(d, attribute, meta),
@@ -284,13 +284,10 @@ func waitForL2SegmentAttribute(d *schema.ResourceData, target string, pending []
 		MinTimeout: 15 * time.Second,
 	}
 
-	return stateConf.WaitForState()
+	return stateConf.WaitForStateContext(ctx)
 }
 
-func newL2SegmentStateRefreshFunc(d *schema.ResourceData, attribute string, meta interface{}) resource.StateRefreshFunc {
-	client := meta.(*scgo.Client)
-	ctx := context.TODO()
-
+func newL2SegmentStateRefreshFunc(d *schema.ResourceData, attribute string, meta interface{}) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		err := resourceServerscomL2SegmentRead(d, meta)
 		if err != nil {
@@ -298,18 +295,12 @@ func newL2SegmentStateRefreshFunc(d *schema.ResourceData, attribute string, meta
 		}
 
 		// See if we can access our attribute
-		if attr, ok := d.GetOkExists(attribute); ok {
-			l2Segment, err := client.L2Segments.Get(ctx, d.Id())
-
-			if err != nil {
-				return nil, "", fmt.Errorf("Error retrieving l2 segment: %s", err)
-			}
-
+		if attr, ok := d.GetOk(attribute); ok {
 			switch attr.(type) {
 			case bool:
-				return &l2Segment, strconv.FormatBool(attr.(bool)), nil
+				return d, strconv.FormatBool(attr.(bool)), nil
 			default:
-				return &l2Segment, attr.(string), nil
+				return d, attr.(string), nil
 			}
 		}
 

--- a/serverscom/resource_serverscom_sbm_server.go
+++ b/serverscom/resource_serverscom_sbm_server.go
@@ -256,7 +256,7 @@ func resourceServerscomSBMCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error waiting for SBM server (%s) to become ready: %s", d.Id(), err)
 	}
 
-	return resourceServerscomSBMRead(d, meta)
+	return nil
 }
 
 func waitForSBMAttribute(ctx context.Context, d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}, timeoutKey string) (interface{}, error) {

--- a/serverscom/resource_serverscom_ssh_key.go
+++ b/serverscom/resource_serverscom_ssh_key.go
@@ -18,7 +18,7 @@ func resourceServerscomSSHKey() *schema.Resource {
 		Delete: resourceServerscomSSHKeyDelete,
 		Create: resourceServerscomSSHKeyCreate,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		SchemaVersion: 1,

--- a/serverscom/resource_serverscom_subnetwork.go
+++ b/serverscom/resource_serverscom_subnetwork.go
@@ -17,7 +17,7 @@ func resourceServerscomSubnetwork() *schema.Resource {
 		Delete: resourceServerscomSubnetworkDelete,
 		Create: resourceServerscomSubnetworkCreate,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		SchemaVersion: 1,


### PR DESCRIPTION
Reduce api read calls for resources with refresh func:
- dedicated server
- sbm server
- l2 segment
- cloud_computing_instance

Update deprecated methods.